### PR TITLE
[DON'T MERGE] Add p2p Shipyard

### DIFF
--- a/landscape-fetch-content/src/repos.ts
+++ b/landscape-fetch-content/src/repos.ts
@@ -131,4 +131,10 @@ export const repos = Schema.decodeSync(Schema.Array(RepoInfo))([
     repo: 'pouchdb-landscape-data',
     basePath: '',
   },
+  {
+    id: 'p2p-shipyard',
+    owner: 'darksoil-studio',
+    repo: 'local-first-landscape-data',
+    basePath: '',
+  },
 ])


### PR DESCRIPTION
This is a temptative PR to add the [p2p Shipyard](https://darksoil.studio/p2p-shipyard) to the local first landscape.

Its goal is to present all the information that would go in the landscape database for the maintainers to consider whether it's actually a good fit or not.

You can access all the information pointed to by this PR [here](https://github.com/darksoil-studio/local-first-landscape-data/blob/main/data.js).